### PR TITLE
Fix bug for CallCredentials not updating

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -154,6 +154,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-jvm</artifactId>
+            <version>1.13.7</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>

--- a/java/src/main/java/com/wgtwo/auth/ClientCredentialSource.java
+++ b/java/src/main/java/com/wgtwo/auth/ClientCredentialSource.java
@@ -33,7 +33,7 @@ public class ClientCredentialSource {
     }
 
     public BearerTokenCallCredentials callCredentials() {
-        return new BearerTokenCallCredentials(fetchToken()::getAccessToken);
+        return new BearerTokenCallCredentials(() -> fetchToken().getAccessToken());
     }
 
     private boolean isExpired(Token token) {

--- a/java/src/test/kotlin/com/wgtwo/auth/BearerTokenCallCredentialsTest.kt
+++ b/java/src/test/kotlin/com/wgtwo/auth/BearerTokenCallCredentialsTest.kt
@@ -1,0 +1,112 @@
+package com.wgtwo.auth
+
+import com.google.common.util.concurrent.MoreExecutors
+import com.wgtwo.testing.chrono.FakeClock
+import com.wgtwo.testing.chrono.minutes
+import io.grpc.CallCredentials
+import io.grpc.Metadata
+import io.grpc.Status
+import io.mockk.mockk
+import java.time.Instant
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.matchers.Times
+import org.mockserver.model.Delay
+import org.mockserver.model.HttpRequest
+import org.mockserver.model.HttpResponse
+
+class BearerTokenCallCredentialsTest {
+
+    @BeforeEach
+    fun setup() {
+        mockServer.reset()
+        mockServerReply("first", "second", "third")
+    }
+
+    @Test
+    fun `refresh token updates`() {
+        val clock = FakeClock(Instant.parse("2000-01-01T00:00:00Z"))
+
+        val auth = WgtwoAuth.builder("client-id", "client-secret")
+            .oauthServer("http://127.0.0.1:" + mockServer.localPort)
+            .clock(clock)
+            .build()
+
+        val tokenSource = auth.clientCredentials.newTokenSource(null)
+        val callCredentials = tokenSource.callCredentials()
+
+        val requestInfo = mockk<CallCredentials.RequestInfo>()
+        val executor = MoreExecutors.directExecutor()
+
+        run {
+            val metadataApplier = MetadataApplier()
+            callCredentials.applyRequestMetadata(requestInfo, executor, metadataApplier)
+            assertThat(metadataApplier.metadata.get(AUTH_KEY)).isEqualTo("Bearer first")
+        }
+
+        // Advance clock 30 minutes (token not expired)
+        clock += 30.minutes
+
+        run {
+            val metadataApplier = MetadataApplier()
+            callCredentials.applyRequestMetadata(requestInfo, executor, metadataApplier)
+            assertThat(metadataApplier.metadata.get(AUTH_KEY)).isEqualTo("Bearer first")
+        }
+
+        // Advance clock another 30 minutes to expire token (token expires after one hour)
+        clock += 30.minutes
+
+        run {
+            val metadataApplier = MetadataApplier()
+            callCredentials.applyRequestMetadata(requestInfo, executor, metadataApplier)
+            assertThat(metadataApplier.metadata.get(AUTH_KEY)).isEqualTo("Bearer second")
+        }
+
+        // Advance clock 60 minutes to expire token (token expires after one hour)
+        clock += 60.minutes
+
+        run {
+            val metadataApplier = MetadataApplier()
+            callCredentials.applyRequestMetadata(requestInfo, executor, metadataApplier)
+            assertThat(metadataApplier.metadata.get(AUTH_KEY)).isEqualTo("Bearer third")
+        }
+    }
+
+    private fun mockServerReply(vararg tokens: String) {
+        tokens.forEach { token ->
+            mockServer.`when`(
+                HttpRequest.request().withMethod("POST").withPath("/oauth2/token"),
+                Times.exactly(1),
+            ).respond(
+                HttpResponse.response()
+                    .withStatusCode(200)
+                    .withBody(
+                        """{
+                          "access_token": "$token",
+                          "expires_in": 3599,
+                          "scope": "",
+                          "token_type": "bearer"
+                        }
+                        """.trimIndent(),
+                    )
+                    .withDelay(Delay.milliseconds(250)),
+            )
+        }
+    }
+
+    companion object {
+        private val mockServer: ClientAndServer = ClientAndServer.startClientAndServer()
+    }
+}
+
+class MetadataApplier : CallCredentials.MetadataApplier() {
+    var metadata = Metadata()
+
+    override fun apply(metadata: Metadata) = this.metadata.merge(metadata)
+
+    override fun fail(status: Status) = Unit
+}
+
+val AUTH_KEY: Metadata.Key<String> = Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)

--- a/java/src/test/kotlin/com/wgtwo/auth/ClientCredentialsTest.kt
+++ b/java/src/test/kotlin/com/wgtwo/auth/ClientCredentialsTest.kt
@@ -1,6 +1,5 @@
-package auth
+package com.wgtwo.auth
 
-import com.wgtwo.auth.WgtwoAuth
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach

--- a/java/src/test/kotlin/com/wgtwo/auth/Sample.kt
+++ b/java/src/test/kotlin/com/wgtwo/auth/Sample.kt
@@ -1,8 +1,7 @@
-package auth
+package com.wgtwo.auth
 
 import com.wgtwo.api.v1.sms.SmsProto.SendTextToSubscriberRequest
 import com.wgtwo.api.v1.sms.SmsServiceGrpc
-import com.wgtwo.auth.WgtwoAuth
 import io.grpc.ManagedChannelBuilder
 
 private val clientId = System.getenv("CLIENT_ID")

--- a/java/src/test/kotlin/com/wgtwo/auth/usage/AuthorizationCode.kt
+++ b/java/src/test/kotlin/com/wgtwo/auth/usage/AuthorizationCode.kt
@@ -1,4 +1,4 @@
-package auth.usage
+package com.wgtwo.auth.usage
 
 import com.wgtwo.auth.Prompt
 import com.wgtwo.auth.model.Token

--- a/java/src/test/kotlin/com/wgtwo/auth/usage/ClientCredentials.kt
+++ b/java/src/test/kotlin/com/wgtwo/auth/usage/ClientCredentials.kt
@@ -1,4 +1,4 @@
-package auth.usage
+package com.wgtwo.auth.usage
 
 import com.wgtwo.api.v1.sms.SmsServiceGrpc
 import io.grpc.ManagedChannelBuilder

--- a/java/src/test/kotlin/com/wgtwo/auth/usage/Setup.kt
+++ b/java/src/test/kotlin/com/wgtwo/auth/usage/Setup.kt
@@ -1,4 +1,4 @@
-package auth.usage
+package com.wgtwo.auth.usage
 
 import com.wgtwo.auth.WgtwoAuth
 

--- a/java/src/test/kotlin/com/wgtwo/testing/chrono/Extensions.kt
+++ b/java/src/test/kotlin/com/wgtwo/testing/chrono/Extensions.kt
@@ -1,0 +1,6 @@
+package com.wgtwo.testing.chrono
+
+import java.time.Duration
+
+val Int.minutes: Duration
+    get() = Duration.ofMinutes(this.toLong())

--- a/java/src/test/kotlin/com/wgtwo/testing/chrono/FakeClock.kt
+++ b/java/src/test/kotlin/com/wgtwo/testing/chrono/FakeClock.kt
@@ -1,0 +1,23 @@
+package com.wgtwo.testing.chrono
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+class FakeClock(
+    private var instant: Instant,
+    private var zoneId: ZoneId = ZoneOffset.UTC,
+) : Clock() {
+    override fun getZone() = zoneId
+    override fun withZone(zone: ZoneId) = this.apply { zoneId = zone }
+    override fun instant() = instant
+
+    @Synchronized
+    fun advance(duration: Duration) {
+        instant += duration
+    }
+
+    operator fun plusAssign(duration: Duration) = advance(duration)
+}


### PR DESCRIPTION
The CallCredentials was not using the token supplier, but continued
to use the first token forever.

The issue was caused by a lambda method accidentially have being
replaced with a method reference.
